### PR TITLE
Redirect Profiler events to Detox Instruments.

### DIFF
--- a/Libraries/Performance/Systrace.js
+++ b/Libraries/Performance/Systrace.js
@@ -187,7 +187,7 @@ const Systrace = {
     if (_enabled) {
       profileName = typeof profileName === 'function' ?
         profileName() : profileName;
-      global.nativeTraceBeginSection(TRACE_TAG_REACT_APPS, profileName, args);
+      global.nativeTraceBeginSection(TRACE_TAG_REACT_APPS, profileName, args || {});
     }
   },
 

--- a/React/Base/RCTBridge.m
+++ b/React/Base/RCTBridge.m
@@ -105,6 +105,42 @@ void* __wix_begin_loadModule(const char* moduleName)
   return (void*)CFBridgingRetain(rv);
 }
 
+void* __wix_begin_event_c(const char* eventName, const char* additionnalInfo);
+void* __wix_begin_event_c(const char* eventName, const char* additionnalInfo)
+{
+  if(__DTXProfilerMarkEventIntervalBegin == NULL)
+  {
+    return NULL;
+  }
+  
+  id rv = __DTXProfilerMarkEventIntervalBegin(@"React Native", [NSString stringWithUTF8String:eventName], [NSString stringWithUTF8String:additionnalInfo]);
+  
+  return (void*)CFBridgingRetain(rv);
+}
+
+void* __wix_begin_jsprofiling_event_c(const char* eventName, const char* additionnalInfo);
+void* __wix_begin_jsprofiling_event_c(const char* eventName, const char* additionnalInfo)
+{
+  if(__DTXProfilerMarkEventIntervalBegin == NULL)
+  {
+    return NULL;
+  }
+  
+  id rv = __DTXProfilerMarkEventIntervalBegin(@"RN JS Profiling", [NSString stringWithUTF8String:eventName], [NSString stringWithUTF8String:additionnalInfo]);
+  
+  return (void*)CFBridgingRetain(rv);
+}
+
+void __wix_mark_event_c(const char* eventName, const char* additionnalInfo);
+void __wix_mark_event_c(const char* eventName, const char* additionnalInfo)
+{
+  if(__DTXProfilerMarkEvent == NULL)
+  {
+    return;
+  }
+  __DTXProfilerMarkEvent(@"React Native", [NSString stringWithUTF8String:eventName], 0, [NSString stringWithUTF8String:additionnalInfo]);
+}
+
 void* __wix_begin_adoptString(const unsigned long long int stringLength);
 void* __wix_begin_adoptString(const unsigned long long int stringLength)
 {

--- a/React/Base/RCTDisplayLink.m
+++ b/React/Base/RCTDisplayLink.m
@@ -114,7 +114,7 @@
   for (RCTModuleData *moduleData in _frameUpdateObservers) {
     id<RCTFrameUpdateObserver> observer = (id<RCTFrameUpdateObserver>)moduleData.instance;
     if (!observer.paused) {
-      RCTProfileBeginFlowEvent();
+      RCTProfileBeginFlowEvent(@"Flow.notifyFrameUpdateObserver", @"");
 
       [self dispatchBlock:^{
         RCTProfileEndFlowEvent();

--- a/React/Base/RCTModuleData.mm
+++ b/React/Base/RCTModuleData.mm
@@ -115,8 +115,6 @@ extern "C" {
 
 - (void)setUpInstanceAndBridge
 {
-  id eventId = __wix_begin_moduleLoad(NSStringFromClass(_moduleClass));
-  
   RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setUpInstanceAndBridge]", @{
     @"moduleClass": NSStringFromClass(_moduleClass)
   });
@@ -128,7 +126,9 @@ extern "C" {
         if (RCT_DEBUG && _requiresMainQueueSetup) {
           RCTAssertMainQueue();
         }
-        RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setUpInstanceAndBridge] Create module", nil);
+        RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setUpInstanceAndBridge] Create module", @{
+                                                                                                                @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                                                });
         _instance = _moduleProvider ? _moduleProvider() : nil;
         RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");
         if (!_instance) {
@@ -173,14 +173,14 @@ extern "C" {
     // thread.
     _requiresMainQueueSetup = NO;
   }
-  
-  __wix_end_event(eventId);
 }
 
 - (void)setBridgeForInstance
 {
   if ([_instance respondsToSelector:@selector(bridge)] && _instance.bridge != _bridge) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setBridgeForInstance]", nil);
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setBridgeForInstance]", @{
+                                                                                            @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                            });
     @try {
       [(id)_instance setValue:_bridge forKey:@"bridge"];
     }
@@ -196,7 +196,9 @@ extern "C" {
 - (void)finishSetupForInstance
 {
   if (!_setupComplete && _instance) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData finishSetupForInstance]", nil);
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData finishSetupForInstance]", @{
+                                                                                              @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                              });
     _setupComplete = YES;
     [_bridge registerModuleForFrameUpdates:_instance withModuleData:self];
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTDidInitializeModuleNotification
@@ -209,7 +211,9 @@ extern "C" {
 - (void)setUpMethodQueue
 {
   if (_instance && !_methodQueue && _bridge.valid) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setUpMethodQueue]", nil);
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData setUpMethodQueue]", @{
+                                                                                        @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                        });
     BOOL implementsMethodQueue = [_instance respondsToSelector:@selector(methodQueue)];
     if (implementsMethodQueue && _bridge.valid) {
       _methodQueue = _instance.methodQueue;
@@ -247,13 +251,17 @@ extern "C" {
 - (id<RCTBridgeModule>)instance
 {
   if (!_setupComplete) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, ([NSString stringWithFormat:@"[RCTModuleData instanceForClass:%@]", _moduleClass]), nil);
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData instance]", @{
+                                                                               @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                               });
     if (_requiresMainQueueSetup) {
       // The chances of deadlock here are low, because module init very rarely
       // calls out to other threads, however we can't control when a module might
       // get accessed by client code during bridge setup, and a very low risk of
       // deadlock is better than a fairly high risk of an assertion being thrown.
-      RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData instance] main thread setup", nil);
+      RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData instance] main thread setup", @{
+                                                                                                    @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                                    });
 
       if (!RCTIsMainQueue()) {
         RCTLogWarn(@"RCTBridge required dispatch_sync to load %@. This may lead to deadlocks", _moduleClass);
@@ -314,7 +322,9 @@ extern "C" {
 - (void)gatherConstants
 {
   if (_hasConstantsToExport && !_constantsToExport) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, ([NSString stringWithFormat:@"[RCTModuleData gatherConstants] %@", _moduleClass]), nil);
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData gatherConstants]", @{
+                                                                                       @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                                       });
     (void)[self instance];
     if (_requiresMainQueueSetup) {
       if (!RCTIsMainQueue()) {
@@ -347,7 +357,9 @@ extern "C" {
     return (id)kCFNull; // Nothing to export
   }
 
-  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, ([NSString stringWithFormat:@"[RCTModuleData config] %@", _moduleClass]), nil);
+  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"[RCTModuleData config]",@{
+                                                                          @"moduleClass": NSStringFromClass(_moduleClass)
+                                                                          });
   NSMutableArray<NSString *> *methods = self.methods.count ? [NSMutableArray new] : nil;
   NSMutableArray<NSNumber *> *promiseMethods = nil;
   NSMutableArray<NSNumber *> *syncMethods = nil;

--- a/React/Base/RCTModuleMethod.mm
+++ b/React/Base/RCTModuleMethod.mm
@@ -436,7 +436,7 @@ RCT_EXTERN_C_END
 - (SEL)selector
 {
   if (_selector == NULL) {
-    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"", (@{ @"module": NSStringFromClass(_moduleClass),
+    RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"RCTModuleMethod call", (@{ @"module": NSStringFromClass(_moduleClass),
                                                           @"method": @(_methodInfo->objcName) }));
     [self processMethodSignature];
     RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");

--- a/React/CxxBridge/RCTCxxBridge.mm
+++ b/React/CxxBridge/RCTCxxBridge.mm
@@ -1048,9 +1048,10 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
   /**
    * AnyThread
    */
-  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[RCTCxxBridge enqueueJSCall:]", nil);
+  RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[RCTCxxBridge enqueueJSCall:]", (@{@"module": module, @"method": method}));
 
-  RCTProfileBeginFlowEvent();
+  NSString* fullMethodName = [NSString stringWithFormat:@"%@.%@", module, method];
+  RCTProfileBeginFlowEvent(@"Flow.postCallJSAfterLoad", fullMethodName);
   [self _runAfterLoad:^{
     RCTProfileEndFlowEvent();
 
@@ -1086,7 +1087,8 @@ RCT_NOT_IMPLEMENTED(- (instancetype)initWithBundleURL:(__unused NSURL *)bundleUR
    * AnyThread
    */
 
-  RCTProfileBeginFlowEvent();
+  NSString* eventName = [NSString stringWithFormat:@"Flow.postCallJSCallbackAfterLoad"];
+  RCTProfileBeginFlowEvent(eventName, @"");
   [self _runAfterLoad:^{
     RCTProfileEndFlowEvent();
 

--- a/React/CxxBridge/RCTJSCHelpers.mm
+++ b/React/CxxBridge/RCTJSCHelpers.mm
@@ -19,7 +19,19 @@
 #import <cxxreact/Platform.h>
 #import <jschelpers/Value.h>
 
+#if RCT_PROFILE
+#import <React/RCTProfile.h>
+#endif
 using namespace facebook::react;
+
+#if RCT_PROFILE
+extern "C" {
+  void wixJSProfileBeginSection(uint64_t tag, const char *name, size_t numArgs, systrace_arg_t *args);
+  void wixProfileEndSection(uint64_t tag, size_t numArgs, systrace_arg_t *args);
+  void wixJSProfileBeginAsyncSection(__unused uint64_t tag, const char *name, int cookie, size_t numArgs, systrace_arg_t *args);
+  void wixJSProfileEndAsyncSection(uint64_t tag, const char *name, int cookie, size_t numArgs, systrace_arg_t *args);
+}
+#endif
 
 namespace {
 
@@ -43,6 +55,78 @@ JSValueRef nativePerformanceNow(
     const JSValueRef arguments[], JSValueRef *exception) {
   return Value::makeNumber(ctx, CACurrentMediaTime() * 1000);
 }
+  
+  JSValueRef nativeTraceBeginAsyncFlowHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceBeginLegacyHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceEndLegacyHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceBeginSectionHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+#if RCT_PROFILE
+    JSStringRef arg1 = JSC_JSStringRetain(ctx,JSC_JSValueToStringCopy(ctx, arguments[1], nullptr));
+    NSString* module = (__bridge NSString*)JSC_JSStringCopyCFString(ctx, NULL, arg1);
+    
+    wixJSProfileBeginSection(0, [module UTF8String], 0, 0);
+    
+    JSC_JSStringRelease(ctx,arg1);
+#endif
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceEndSectionHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+#if RCT_PROFILE    
+    wixProfileEndSection(0, 0, 0);
+#endif
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceBeginAsyncSectionHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+#if RCT_PROFILE
+    JSStringRef arg1 = JSC_JSStringRetain(ctx,JSC_JSValueToStringCopy(ctx, arguments[1], nullptr));
+    NSString* module = (__bridge NSString*)JSC_JSStringCopyCFString(ctx, NULL, arg1);
+    int cookie = (int)JSC_JSValueToNumber(ctx, arguments[2], nullptr);
+
+    wixJSProfileBeginAsyncSection(0, [module UTF8String], cookie, 0, 0);
+
+    JSC_JSStringRelease(ctx,arg1);
+#endif
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceEndAsyncSectionHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+#if RCT_PROFILE
+    int cookie = (int)JSC_JSValueToNumber(ctx, arguments[2], nullptr);
+    wixJSProfileEndAsyncSection(0, 0, cookie, 0, 0);
+#endif
+    return Value::makeUndefined(ctx);
+  }
+  
+  JSValueRef nativeTraceCounterHook(
+                                           JSContextRef ctx, JSObjectRef function, JSObjectRef thisObject, size_t argumentCount,
+                                           const JSValueRef arguments[], JSValueRef *exception) {
+    return Value::makeUndefined(ctx);
+  }
 
 }
 
@@ -51,4 +135,13 @@ void RCTPrepareJSCExecutor() {
   JSCNativeHooks::loggingHook = nativeLoggingHook;
   JSCNativeHooks::nowHook = nativePerformanceNow;
   JSCNativeHooks::installPerfHooks = RCTFBQuickPerformanceLoggerConfigureHooks;
+
+  JSCNativeHooks::nativeTraceBeginAsyncFlowHook = nativeTraceBeginAsyncFlowHook;
+  JSCNativeHooks::nativeTraceBeginLegacyHook = nativeTraceBeginLegacyHook;
+  JSCNativeHooks::nativeTraceEndLegacyHook = nativeTraceEndLegacyHook;
+  JSCNativeHooks::nativeTraceBeginSectionHook = nativeTraceBeginSectionHook;
+  JSCNativeHooks::nativeTraceEndSectionHook = nativeTraceEndSectionHook;
+  JSCNativeHooks::nativeTraceBeginAsyncSectionHook = nativeTraceBeginAsyncSectionHook;
+  JSCNativeHooks::nativeTraceEndAsyncSectionHook = nativeTraceEndAsyncSectionHook;
+  JSCNativeHooks::nativeTraceCounterHook = nativeTraceCounterHook;
 }

--- a/React/CxxBridge/RCTObjcExecutor.mm
+++ b/React/CxxBridge/RCTObjcExecutor.mm
@@ -75,7 +75,7 @@ public:
   void loadApplicationScript(
       std::unique_ptr<const JSBigString> script,
       std::string sourceURL) override {
-    RCTProfileBeginFlowEvent();
+    RCTProfileBeginFlowEvent(@"Flow.loadApplicationScript", @"");
     [m_jse executeApplicationScript:[NSData dataWithBytes:script->c_str() length:script->size()]
            sourceURL:[[NSURL alloc]
                          initWithString:@(sourceURL.c_str())]

--- a/React/CxxModule/RCTNativeModule.mm
+++ b/React/CxxModule/RCTNativeModule.mm
@@ -50,7 +50,7 @@ std::vector<MethodDescriptor> RCTNativeModule::getMethods() {
 
 folly::dynamic RCTNativeModule::getConstants() {
   RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways,
-    @"[RCTNativeModule getConstants] moduleData.exportedConstants", nil);
+                          @"[RCTNativeModule getConstants] moduleData.exportedConstants", @{@"module": NSStringFromClass(m_moduleData.moduleClass)});
   NSDictionary *constants = m_moduleData.exportedConstants;
   folly::dynamic ret = convertIdToFollyDynamic(constants);
   RCT_PROFILE_END_EVENT(RCTProfileTagAlways, @"");

--- a/React/Modules/RCTUIManager.m
+++ b/React/Modules/RCTUIManager.m
@@ -1126,7 +1126,7 @@ RCT_EXPORT_METHOD(dispatchViewManagerCommand:(nonnull NSNumber *)reactTag
 
   if (previousPendingUIBlocks.count) {
     // Execute the previously queued UI blocks
-    RCTProfileBeginFlowEvent();
+    RCTProfileBeginFlowEvent(@"Flow.flushUIBlocks", @"");
     RCTExecuteOnMainQueue(^{
       RCTProfileEndFlowEvent();
       RCT_PROFILE_BEGIN_EVENT(RCTProfileTagAlways, @"-[UIManager flushUIBlocks]", (@{

--- a/React/Profiler/RCTProfile.h
+++ b/React/Profiler/RCTProfile.h
@@ -30,10 +30,10 @@ RCT_EXTERN const uint64_t RCTProfileTagAlways;
 
 @class RCTBridge;
 
-#define RCTProfileBeginFlowEvent() \
+#define RCTProfileBeginFlowEvent(name, argument) \
 _Pragma("clang diagnostic push") \
 _Pragma("clang diagnostic ignored \"-Wshadow\"") \
-NSUInteger __rct_profile_flow_id = _RCTProfileBeginFlowEvent(); \
+NSUInteger __rct_profile_flow_id = _RCTProfileBeginFlowEvent(name, argument); \
 _Pragma("clang diagnostic pop")
 
 #define RCTProfileEndFlowEvent() \
@@ -41,7 +41,7 @@ _RCTProfileEndFlowEvent(__rct_profile_flow_id)
 
 RCT_EXTERN dispatch_queue_t RCTProfileGetQueue(void);
 
-RCT_EXTERN NSUInteger _RCTProfileBeginFlowEvent(void);
+RCT_EXTERN NSUInteger _RCTProfileBeginFlowEvent(NSString* name, NSString* argument);
 RCT_EXTERN void _RCTProfileEndFlowEvent(NSUInteger);
 
 /**
@@ -186,7 +186,7 @@ typedef struct {
 
   void (*instant_section)(uint64_t tag, const char *name, char scope);
 
-  void (*begin_async_flow)(uint64_t tag, const char *name, int cookie);
+  void (*begin_async_flow)(uint64_t tag, const char *name, int cookie, const char* argument);
   void (*end_async_flow)(uint64_t tag, const char *name, int cookie);
 } RCTProfileCallbacks;
 


### PR DESCRIPTION
Changelog:
----------
  [iOS] [Added] - Enabled RCT_PROFILE preprocessor definition to log React Native events into Detox Instruments. And reformatted some of the profiling events so that they are more readable and classifiable, (class name, method name)

![screen shot 2018-12-20 at 5 01 32 pm](https://user-images.githubusercontent.com/28295447/50292112-f84ea100-0478-11e9-8df6-bb418f53ee4e.png)

