### PR TITLE
feat: enforceable systrace via env var

### DIFF
--- a/Libraries/Performance/Systrace.js
+++ b/Libraries/Performance/Systrace.js
@@ -10,6 +10,7 @@
 
 'use strict';
 
+const __DEV__ = global.__DEV__ || global.__FORCE_SYSTRACE__;
 const invariant = require('fbjs/lib/invariant');
 
 const TRACE_TAG_REACT_APPS = 1 << 17; // eslint-disable-line no-bitwise


### PR DESCRIPTION
Test Plan:
----------
- [x] verify build without metro bundler fork
- [x] verify build with metro bundler fork and no FORCE_SYSTRACE env variable
- [x] verify build with metro bundler fork and FORCE_SYSTRACE=1 env variable
- [x] test app end-to-end in production mode with enforced Systrace class (works [after fixes to react-native-js-profiler](https://github.com/wix-incubator/react-native-js-profiler/commit/28820195732afe94d39c8f88c7a0527deeb3feb4))

Changelog:
----------
* [General] preserves Systrace.js in production code if the build occurred with a truthy environment variable FORCE_SYSTRACE (the bundle has __FORCE_SYSTRACE__ global equal to true).